### PR TITLE
Configure tests on Travis and AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,45 @@
+version: '{build}'
+image: Visual Studio 2015
+platform:
+- x86
+- x64
+environment:
+  global:
+    DISTUTILS_USE_SDK: 1
+    MSSdk: 1
+  matrix:
+  - PYTHON: 27
+  - PYTHON: 35
+  - CONDA: 27
+  - CONDA: 35
+matrix:
+  allow_failures:
+  - platform: x86
+    CONDA: 27
+install:
+- cmd: '"%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%'
+- ps: |
+    if ($env:PYTHON) {
+      if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }
+      $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"
+      pip install --disable-pip-version-check --user --upgrade pip
+    } elseif ($env:CONDA) {
+      if ($env:CONDA -eq "27") { $env:CONDA = "" }
+      if ($env:PLATFORM -eq "x64") { $env:CONDA = "$env:CONDA-x64" }
+      $env:PATH = "C:\Miniconda$env:CONDA\;C:\Miniconda$env:CONDA\Scripts\;$env:PATH"
+      conda config --set always_yes yes --set changeps1 no
+      conda config --add channels conda-forge
+      conda update -q conda
+      conda install -q conda-build
+    }
+build_script:
+- ps: |
+    if ($env:PYTHON) {
+      python setup.py sdist
+      pip install --verbose dist\python_example-0.0.1.zip
+    } elseif ($env:CONDA) {
+      conda build conda.recipe
+      conda install --use-local python_example
+    }
+test_script:
+- ps: python tests\test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: cpp
+os:
+- linux
+- osx
+env:
+- PYTHON=2.7
+- PYTHON=3.5
+- CONDA=2.7
+- CONDA=3.5
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - deadsnakes
+    packages:
+    - g++-4.8
+    - python3.5
+    - python3.5-dev
+before_install:
+- |
+  if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX=g++-4.8 CC=gcc-4.8; fi
+  if [ -n "$PYTHON" ]; then
+    if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$PYTHON" = "3.5" ]; then
+      brew update; brew install python3;
+    fi
+    pip install --user --upgrade pip virtualenv
+    virtualenv -p python$PYTHON venv
+    source venv/bin/activate
+  elif [ -n "$CONDA" ]; then
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then OS=Linux-x86_64; else OS=MacOSX-x86_64; fi
+    wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda${CONDA:0:1}-latest-$OS.sh
+    bash miniconda.sh -b -p $HOME/miniconda
+    export PATH="$HOME/miniconda/bin:$PATH"
+    conda config --set always_yes yes --set changeps1 no
+    conda config --add channels conda-forge
+    conda update -q conda
+    conda install -q conda-build
+    conda create -q -n test-environment python=$CONDA
+    source activate test-environment
+  fi
+install:
+- |
+  if [ -n "$PYTHON" ]; then
+    python setup.py sdist
+    pip install --verbose dist/*.tar.gz
+  elif [ -n "$CONDA" ]; then
+    conda build conda.recipe
+    conda install --use-local python_example
+  fi
+script:
+- python tests/test.py

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,4 +1,5 @@
-call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x64
+if "%ARCH%" == "32" (set PLATFORM=x86) else (set PLATFORM=x64)
+call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%
 set DISTUTILS_USE_SDK=1
 set MSSdk=1
 "%PYTHON%" setup.py install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: python_example
-  version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG', 'dev') }}
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -6,6 +6,9 @@ build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   {% if environ.get('GIT_DESCRIBE_NUMBER', '0') == '0' %}string: py{{ environ.get('PY_VER').replace('.', '') }}_0
   {% else %}string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}{% endif %}
+  script_env:
+    - CC
+    - CXX
 
 source:
   git_url: ../

--- a/setup.py
+++ b/setup.py
@@ -78,11 +78,13 @@ class BuildExt(build_ext):
     def build_extensions(self):
         ct = self.compiler.compiler_type
         opts = self.c_opts.get(ct, [])
-        opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
         if ct == 'unix':
+            opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
             opts.append(cpp_flag(self.compiler))
             if has_flag(self.compiler, '-fvisibility=hidden'):
                 opts.append('-fvisibility=hidden')
+        elif ct == 'msvc':
+            opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
         for ext in self.extensions:
             ext.extra_compile_args = opts
         build_ext.build_extensions(self)

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,5 @@
+import python_example as m
+
+assert m.__version__ == '0.0.1'
+assert m.add(1, 2) == 3
+assert m.subtract(1, 2) == -1


### PR DESCRIPTION
As discussed in pybind/cmake_example#4, this adds `.travis.yml` and `.appveyor.yml` configurations to test the build using `pip` and `conda`.

You'll need to activate the two services for this repository. These are just the config files.
For a sample of the test output, see the logs from my fork:
https://travis-ci.org/dean0x7d/python_example
https://ci.appveyor.com/project/dean0x7d/python-example

It tests a large number of configurations: `pip` and `conda`, 2.7 and 3.5, Linux, OS X and Windows x86/x64. This has revealed a few issues. I fixed each one in a separate commit for clarity. Let me know if there is a better solution for any of those, I'm not that familiar with `conda-build` so I may have worked around something obvious.

The only issue I wasn't able to resolve is Conda 2.7-x86 on Windows. I have no idea why it doesn't build and I can't reproduce the issue on my local VM. For now, I've placed this particular configuration under `allow_failures` on AppVeyor.

One last thing: the conda tests are configured to fetch `pybind11` from the `conda-forge` channel. I originally used the `pybind` channel, but this resulted in a crash with Conda 2.7 on Linux and OS X. I have no idea why that was, `conda-build` would either crash or loop endlessly. In any case, switching to the `conda-forge` version resolved it.