### PR TITLE
CI config maintenance

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,20 +9,16 @@ environment:
     MSSdk: 1
   matrix:
   - PYTHON: 27
-  - PYTHON: 35
+  - PYTHON: 36
   - CONDA: 27
   - CONDA: 35
-matrix:
-  allow_failures:
-  - platform: x86
-    CONDA: 27
 install:
 - cmd: '"%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%'
 - ps: |
     if ($env:PYTHON) {
       if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }
       $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"
-      pip install --disable-pip-version-check --user --upgrade pip
+      pip install --disable-pip-version-check --user --upgrade pip setuptools
     } elseif ($env:CONDA) {
       if ($env:CONDA -eq "27") { $env:CONDA = "" }
       if ($env:PLATFORM -eq "x64") { $env:CONDA = "$env:CONDA-x64" }
@@ -36,8 +32,8 @@ build_script:
 - ps: |
     if ($env:PYTHON) {
       python setup.py sdist
-      pip install --verbose dist\python_example-0.0.1.zip
-    } elseif ($env:CONDA) {
+      pip install --verbose dist\python_example-0.0.1.tar.gz
+    } else {
       conda build conda.recipe
       conda install --use-local python_example
     }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
 language: cpp
-os:
-- linux
-- osx
-env:
-- PYTHON=2.7
-- PYTHON=3.5
-- CONDA=2.7
-- CONDA=3.5
+matrix:
+  include:
+  - os: linux
+    env: PYTHON=2.7
+  - os: linux
+    env: PYTHON=3.5
+  - os: linux
+    env: CONDA=2.7
+  - os: linux
+    env: CONDA=3.5
+  - os: osx
+    env: PYTHON=2.7
+  - os: osx
+    env: PYTHON=3.6
+  - os: osx
+    env: CONDA=2.7
+  - os: osx
+    env: CONDA=3.5
 addons:
   apt:
     sources:
@@ -20,7 +30,7 @@ before_install:
 - |
   if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX=g++-4.8 CC=gcc-4.8; fi
   if [ -n "$PYTHON" ]; then
-    if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$PYTHON" = "3.5" ]; then
+    if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "${PYTHON:0:1}" = "3" ]; then
       brew update; brew install python3;
     fi
     pip install --user --upgrade pip virtualenv


### PR DESCRIPTION
This fixes CI test failures due to recent Python updates:

* Fixed homebrew config -> now installs Python 3.6.
* Fixed Windows config -> the default `sdist` file extension changed from `.zip` to `.tar.gz`.
* Removed windows conda 2.7 config from `allow_failures` since it passes now.

This matches recent changes in [pybind/cmake_example](https://github.com/pybind/cmake_example).