### PR TITLE
Appveyor: Change pip to python -m pip

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ install:
     if ($env:PYTHON) {
       if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }
       $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"
-      pip install --disable-pip-version-check --user --upgrade pip setuptools
+      python -m pip install --disable-pip-version-check --user --upgrade pip setuptools
     } elseif ($env:CONDA) {
       if ($env:CONDA -eq "27") { $env:CONDA = "" }
       if ($env:PLATFORM -eq "x64") { $env:CONDA = "$env:CONDA-x64" }


### PR DESCRIPTION
See https://github.com/pypa/pip/issues/5223 - there is a pip 9 to 10 upgrade issue that prevents a direct `pip install ... --upgrade pip` from working.

While the issue is closed in pip upstream, it still seems to cause problems.