### PR TITLE
Use define_macros for macros

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,22 +71,29 @@ class BuildExt(build_ext):
         'msvc': ['/EHsc'],
         'unix': [],
     }
+    l_opts = {
+        'msvc': [],
+        'unix': [],
+    }
 
     if sys.platform == 'darwin':
+        l_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
         c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
 
     def build_extensions(self):
         ct = self.compiler.compiler_type
-        opts = self.c_opts.get(ct, [])
+        c_opts = self.c_opts.get(ct, [])
+        l_opts = self.l_opts.get(ct, [])
         if ct == 'unix':
-            opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
-            opts.append(cpp_flag(self.compiler))
+            c_opts.append(cpp_flag(self.compiler))
             if has_flag(self.compiler, '-fvisibility=hidden'):
-                opts.append('-fvisibility=hidden')
-        elif ct == 'msvc':
-            opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
+                c_opts.append('-fvisibility=hidden')
+
         for ext in self.extensions:
-            ext.extra_compile_args = opts
+            ext.extra_compile_args = c_opts
+            ext.extra_link_args = l_opts
+            ext.define_macros = [('VERSION_INFO', '"{}"'.format(self.distribution.get_version()))]
+
         build_ext.build_extensions(self)
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -86,9 +86,9 @@ class BuildExt(build_ext):
         opts = self.c_opts.get(ct, [])
         link_opts = self.l_opts.get(ct, [])
         if ct == 'unix':
-            c_opts.append(cpp_flag(self.compiler))
+            opts.append(cpp_flag(self.compiler))
             if has_flag(self.compiler, '-fvisibility=hidden'):
-                c_opts.append('-fvisibility=hidden')
+                opts.append('-fvisibility=hidden')
 
         for ext in self.extensions:
             ext.define_macros = [('VERSION_INFO', '"{}"'.format(self.distribution.get_version()))]


### PR DESCRIPTION
Moves `VERSION_INFO` to `define_macros`
Copies `stdlib` flag to link time as well.