### PR TITLE
Use C++17 compile flag when possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,17 +52,17 @@ def has_flag(compiler, flagname):
 
 
 def cpp_flag(compiler):
-    """Return the -std=c++[11/14] compiler flag.
+    """Return the -std=c++[11/14/17] compiler flag.
 
-    The c++14 is prefered over c++11 (when it is available).
+    The newer version is prefered over c++11 (when it is available).
     """
-    if has_flag(compiler, '-std=c++14'):
-        return '-std=c++14'
-    elif has_flag(compiler, '-std=c++11'):
-        return '-std=c++11'
-    else:
-        raise RuntimeError('Unsupported compiler -- at least C++11 support '
-                           'is needed!')
+    flags = ['-std=c++17', '-std=c++14', '-std=c++11']
+
+    for flag in flags:
+        if has_flag(compiler, flag): return flag
+
+    raise RuntimeError('Unsupported compiler -- at least C++11 support '
+                       'is needed!')
 
 
 class BuildExt(build_ext):


### PR DESCRIPTION
Setup.py now checks for support of `-c++17` flag in addition for `-c++14` and `-c++11` flags and compiles using it when supported. 

Also refactored a code a little bit, to avoid a pile of 'ifs' in the future.