### PR TITLE
Adds linker options needed for compilation on recent OSX system 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,13 +71,20 @@ class BuildExt(build_ext):
         'msvc': ['/EHsc'],
         'unix': [],
     }
+    l_opts = {
+        'msvc': [],
+        'unix': [],
+    }
 
     if sys.platform == 'darwin':
-        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
+        darwin_opts = ['-stdlib=libc++', '-mmacosx-version-min=10.7']
+        c_opts['unix'] += darwin_opts
+        l_opts['unix'] += darwin_opts
 
     def build_extensions(self):
         ct = self.compiler.compiler_type
         opts = self.c_opts.get(ct, [])
+        link_opts = self.l_opts.get(ct, [])
         if ct == 'unix':
             opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
             opts.append(cpp_flag(self.compiler))
@@ -87,6 +94,7 @@ class BuildExt(build_ext):
             opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
         for ext in self.extensions:
             ext.extra_compile_args = opts
+            ext.extra_link_args = link_opts
         build_ext.build_extensions(self)
 
 setup(


### PR DESCRIPTION
As reported in issue #22, linking would fail on recent OSX system (mine is Mojave 10.14.4).

```
python setup.py build_ext --inplace
running build_ext
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/scheibler/anaconda3/envs/mixiva/include -arch x86_64 -I/Users/scheibler/anaconda3/envs/mixiva/include -arch x86_64 -I/Users/scheibler/anaconda3/envs/mixiva/include/python3.7m -c /var/folders/jg/dwzzdbk97txcldqz4141dwdm0000gp/T/tmpvn084ynb.cpp -o var/folders/jg/dwzzdbk97txcldqz4141dwdm0000gp/T/tmpvn084ynb.o -std=c++14
warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use
      the libc++ standard library instead [-Wstdlibcxx-not-found]
1 warning generated.
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/scheibler/anaconda3/envs/mixiva/include -arch x86_64 -I/Users/scheibler/anaconda3/envs/mixiva/include -arch x86_64 -I/Users/scheibler/anaconda3/envs/mixiva/include/python3.7m -c /var/folders/jg/dwzzdbk97txcldqz4141dwdm0000gp/T/tmpu_hkqi17.cpp -o var/folders/jg/dwzzdbk97txcldqz4141dwdm0000gp/T/tmpu_hkqi17.o -fvisibility=hidden
warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use
      the libc++ standard library instead [-Wstdlibcxx-not-found]
1 warning generated.
building 'python_example' extension
creating build
creating build/temp.macosx-10.7-x86_64-3.7
creating build/temp.macosx-10.7-x86_64-3.7/src
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/scheibler/anaconda3/envs/mixiva/include -arch x86_64 -I/Users/scheibler/anaconda3/envs/mixiva/include -arch x86_64 -I/Users/scheibler/anaconda3/envs/mixiva/include/python3.7m -I/Users/scheibler/.local/include/python3.7m -I/Users/scheibler/anaconda3/envs/mixiva/include/python3.7m -c src/main.cpp -o build/temp.macosx-10.7-x86_64-3.7/src/main.o -stdlib=libc++ -mmacosx-version-min=10.7 -DVERSION_INFO="0.0.1" -std=c++14 -fvisibility=hidden
creating build/lib.macosx-10.7-x86_64-3.7
g++ -bundle -undefined dynamic_lookup -L/Users/scheibler/anaconda3/envs/mixiva/lib -arch x86_64 -L/Users/scheibler/anaconda3/envs/mixiva/lib -arch x86_64 -arch x86_64 build/temp.macosx-10.7-x86_64-3.7/src/main.o -o build/lib.macosx-10.7-x86_64-3.7/python_example.cpython-37m-darwin.so
clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9 [-Wdeprecated]
ld: library not found for -lstdc++
clang: error: linker command failed with exit code 1 (use -v to see invocation)
error: command 'g++' failed with exit status 1
```

The error was solved by passing the flags `['-stdlib=libc++', '-mmacosx-version-min=10.7']` to the linker as well in `BuildExt`.

I tried to handle this in a way that would allow potentially to add different flags for compile/link. Please let me know if that's the way to go. The example now compiles, at least for me.