### PR TITLE
Suggest sorting of extension sources to ensure a reproducible build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class get_pybind_include(object):
 ext_modules = [
     Extension(
         'python_example',
-        ['src/main.cpp'],
+        sorted(['src/main.cpp']),
         include_dirs=[
             # Path to pybind11 headers
             get_pybind_include(),


### PR DESCRIPTION
This PR suggests the sorting of extension sources to ensure a reproducible build regardless of the layout on the file system. For example, in [my PR to pikepdf](https://github.com/pikepdf/pikepdf/pull/76):

```
-        glob('src/qpdf/*.cpp'),
+       sorted(glob('src/qpdf/*.cpp')),
```

… otherwise the sources were iterated and linked in a nondeterminstic order and thus the build was not bit-for-bit identical on subsequent build runs.