### PR TITLE
Add header includes by default from the source folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ __version__ = "0.0.1"
 ext_modules = [
     Pybind11Extension("python_example",
         ["src/main.cpp"],
+        include_dirs = ["src"],
         # Example: passing in the version to the compiled code
         define_macros = [('VERSION_INFO', __version__)],
         ),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+from glob import glob
 
 # Available at setup time due to pyproject.toml
 from pybind11 import get_cmake_dir
@@ -18,7 +19,7 @@ __version__ = "0.0.1"
 
 ext_modules = [
     Pybind11Extension("python_example",
-        ["src/main.cpp"],
+        sorted(glob("src/*.cpp")) + glob("src/*.hpp"),
         include_dirs = ["src"],
         # Example: passing in the version to the compiled code
         define_macros = [('VERSION_INFO', __version__)],


### PR DESCRIPTION
When people use this example for a multi-file code project, they will get an error during build where the header files are not found. Suggest adding this line of code to the template so that fewer users will run into this problem when basing their project on this template.